### PR TITLE
fix: add url encoding character to regex

### DIFF
--- a/rootfs/etc/varnish/default.vcl
+++ b/rootfs/etc/varnish/default.vcl
@@ -82,7 +82,7 @@ sub vcl_recv {
     #  Ignore query strings that are only necessary for the js on the client. Customize as needed.
     if (req.url ~ "(\?|&)(pk_campaign|piwik_campaign|pk_kwd|piwik_kwd|pk_keyword|pixelId|kwid|kw|adid|chl|dv|nk|pa|camid|adgid|cx|ie|cof|siteurl|utm_[a-z]+|_ga|gclid)=") {
         # see rfc3986#section-2.3 "Unreserved Characters" for regex
-        set req.url = regsuball(req.url, "(pk_campaign|piwik_campaign|pk_kwd|piwik_kwd|pk_keyword|pixelId|kwid|kw|adid|chl|dv|nk|pa|camid|adgid|cx|ie|cof|siteurl|utm_[a-z]+|_ga|gclid)=[A-Za-z0-9\-\_\.\~]+&?", "");
+        set req.url = regsuball(req.url, "(pk_campaign|piwik_campaign|pk_kwd|piwik_kwd|pk_keyword|pixelId|kwid|kw|adid|chl|dv|nk|pa|camid|adgid|cx|ie|cof|siteurl|utm_[a-z]+|_ga|gclid)=[A-Za-z0-9\-\_\.\~%]+&?", "");
     }
 
     set req.url = regsub(req.url, "(\?|\?&|&)$", "");


### PR DESCRIPTION
Add the `%` character to the regex to support url-encoded URLs with special chars.
Without this, the replace does not work properly:

Example `&utm_content=Herbstgef%C3%BChle`

Without the change, this gets replaced to `%C3%BChle`.