### PR TITLE
fix: strip cookies from static asset requests

### DIFF
--- a/rootfs/etc/varnish/default.vcl
+++ b/rootfs/etc/varnish/default.vcl
@@ -70,6 +70,13 @@ sub vcl_recv {
         return (pass);
     }
 
+    # Static assets don't need any cookie. Stripping them ensures a stable cache
+    # key when assets are served from the same domain as the storefront, so the
+    # hash does not vary based on sw-cache-hash or sw-currency.
+    if (req.url ~ "^/(media|thumbnail|theme|bundles)/") {
+        unset req.http.Cookie;
+    }
+
     cookie.parse(req.http.cookie);
 
     # set cache-hash cookie value to header for hashing based on vary header


### PR DESCRIPTION
## Description

This ports the static asset cookie handling from shopware/recipes#260 to the Shopware Varnish image.

When assets are served from the storefront domain, browsers send `sw-cache-hash` and `sw-currency` cookies with those requests. The VCL parses these cookies and includes their values in the cache hash, creating multiple cache entries for identical assets.

The cookie header is now removed before parsing for `/media`, `/thumbnail`, `/theme`, and `/bundles` requests. This keeps one stable cache entry per asset while leaving storefront requests unchanged.

The Docker image builds successfully, including all 59 bundled Varnish module tests, and `varnishd -C` validates the resulting VCL.
