### PR TITLE
fix: strip cookies from static asset requests

### DIFF
--- a/rootfs/etc/varnish/default.vcl
+++ b/rootfs/etc/varnish/default.vcl
@@ -70,6 +70,12 @@ sub vcl_recv {
         return (pass);
     }
 
+    # Static assets don't need cookies. Strip them before parsing when assets
+    # are served from the same domain as the storefront.
+    if (req.url ~ "^/(media|thumbnail|theme|bundles)/") {
+        unset req.http.Cookie;
+    }
+
     cookie.parse(req.http.cookie);
 
     # set cache-hash cookie value to header for hashing based on vary header


### PR DESCRIPTION
## Description

This backports the static asset cookie handling from shopware/recipes#260 and shopware/varnish-shopware#43 to the `6.8` branch.

When assets are served from the storefront domain, browsers send Shopware cookies with those requests even though static assets are cookie-independent. The cookie header is now removed before parsing for `/media`, `/thumbnail`, `/theme`, and `/bundles` requests, keeping these requests independent of the visitor context.

The 6.8 Docker image builds successfully, including all 59 bundled Varnish module tests, and `varnishd -C` validates the resulting VCL.
